### PR TITLE
Add `stateless_apply`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.11"
+version = "0.1.10"
 
 [deps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.9"
+version = "0.1.11"
 
 [deps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -132,7 +132,7 @@ apply(model::AbstractExplicitLayer, x, ps, st) = model(x, ps, st)
 Calls `apply` and only returns the first argument.
 """
 function stateless_apply(model::AbstractExplicitLayer, x, ps, st)
-    first(apply(model, x, ps, st))
+    return first(apply(model, x, ps, st))
 end
 
 function stateless_apply(model, x, ps, st)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -127,7 +127,7 @@ Simply calls `model(x, ps, st)`
 apply(model::AbstractExplicitLayer, x, ps, st) = model(x, ps, st)
 
 """
-    stateless_apply(model, x, ps, st)
+    stateless_apply(model, x, ps)
 
 Calls `apply` and only returns the first argument.
 """
@@ -186,6 +186,18 @@ end
 
 function statelength(l::AbstractExplicitContainerLayer{layers}) where {layers}
     return sum(statelength, getfield.((l,), layers))
+end
+
+function stateless_apply(
+        model::AbstractExplicitContainerLayer{layers}, x, ps) where {layers}
+    if length(layers) == 1
+        layer_names = keys(getfield(model, layers[1]))
+    else
+        layer_names = layers
+    end
+    st = NamedTuple{layer_names}(NamedTuple() for _ in layer_names)
+
+    return first(apply(model, x, ps, st))
 end
 
 # Make AbstractExplicit Layers Functor Compatible

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -131,14 +131,8 @@ apply(model::AbstractExplicitLayer, x, ps, st) = model(x, ps, st)
 
 Calls `apply` and only returns the first argument.
 """
-function stateless_apply(model::AbstractExplicitLayer, x, ps, st)
-    return first(apply(model, x, ps, st))
-end
-
-function stateless_apply(model, x, ps, st)
-    u, st = apply(model, x, ps, st)
-    @assert isempty(st) "Model is not stateless. Use `apply` instead."
-    return u
+function stateless_apply(model::AbstractExplicitLayer, x, ps)
+    return first(apply(model, x, ps, NamedTuple()))
 end
 
 """

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -194,7 +194,7 @@ function statelength(l::AbstractExplicitContainerLayer{layers}) where {layers}
 end
 
 function _getemptystate(l::AbstractExplicitContainerLayer{layers}) where {layers}
-    length(layers) == 1 && return _getemptystate(getfield(l, length(layers)))
+    length(layers) == 1 && return _getemptystate(getfield(l, first(layers)))
     return NamedTuple{layers}(_getemptystate.(getfield.((l,), layers)))
 end
 

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -127,6 +127,21 @@ Simply calls `model(x, ps, st)`
 apply(model::AbstractExplicitLayer, x, ps, st) = model(x, ps, st)
 
 """
+    stateless_apply(model, x, ps, st)
+
+Calls `apply` and only returns the first argument.
+"""
+function stateless_apply(model::AbstractExplicitLayer, x, ps, st)
+    first(apply(model, x, ps, st))
+end
+
+function stateless_apply(model, x, ps, st)
+    u, st = apply(model, x, ps, st)
+    @assert isempty(st) "Model is not stateless. Use `apply` instead."
+    return u
+end
+
+"""
     display_name(layer::AbstractExplicitLayer)
 
 Printed Name of the `layer`. If the `layer` has a field `name` that is used, else the type

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -70,9 +70,9 @@ function initialstates(rng::AbstractRNG, l)
     throw(MethodError(initialstates, (rng, l)))
 end
 
-_getstate(::AbstractExplicitLayer) = NamedTuple()
-function _getstate(l::NamedTuple{fields}) where {fields}
-    return NamedTuple{fields}(map(_getstate, values(l)))
+_getemptystate(::AbstractExplicitLayer) = NamedTuple()
+function _getemptystate(l::NamedTuple{fields}) where {fields}
+    return NamedTuple{fields}(map(_getemptystate, values(l)))
 end
 
 """
@@ -137,7 +137,7 @@ apply(model::AbstractExplicitLayer, x, ps, st) = model(x, ps, st)
 Calls `apply` and only returns the first argument.
 """
 function stateless_apply(model::AbstractExplicitLayer, x, ps)
-    return first(apply(model, x, ps, _getstate(model)))
+    return first(apply(model, x, ps, _getemptystate(model)))
 end
 
 """
@@ -193,9 +193,9 @@ function statelength(l::AbstractExplicitContainerLayer{layers}) where {layers}
     return sum(statelength, getfield.((l,), layers))
 end
 
-function _getstate(l::AbstractExplicitContainerLayer{layers}) where {layers}
-    length(layers) == 1 && return _getstate(getfield(l, length(layers)))
-    return NamedTuple{layers}(_getstate.(getfield.((l,), layers)))
+function _getemptystate(l::AbstractExplicitContainerLayer{layers}) where {layers}
+    length(layers) == 1 && return _getemptystate(getfield(l, length(layers)))
+    return NamedTuple{layers}(_getemptystate.(getfield.((l,), layers)))
 end
 
 # Make AbstractExplicit Layers Functor Compatible

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,8 +47,8 @@ end
 
             @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
-            @test LuxCore.stateless_apply(model, x, ps, st) ==
-                  first(LuxCore.apply(model, x, ps, st))
+            @test LuxCore.stateless_apply(model, x, ps) ==
+                  first(LuxCore.apply(model, x, ps, NamedTuple()))
 
             @test_nowarn println(model)
         end
@@ -91,8 +91,8 @@ end
 
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
-        @test LuxCore.stateless_apply(model, x, ps, st) ==
-              first(LuxCore.apply(model, x, ps, st))
+        @test LuxCore.stateless_apply(model, x, ps) ==
+              first(LuxCore.apply(model, x, ps, NamedTuple()))
 
         @test_nowarn println(model)
 
@@ -109,8 +109,8 @@ end
 
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
-        @test LuxCore.stateless_apply(model, x, ps, st) ==
-              first(LuxCore.apply(model, x, ps, st))
+        @test LuxCore.stateless_apply(model, x, ps) ==
+              first(LuxCore.apply(model, x, ps, NamedTuple()))
 
         @test_nowarn println(model)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,7 @@ end
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
         @test LuxCore.stateless_apply(model, x, ps) ==
-              first(LuxCore.apply(model, x, ps, NamedTuple()))
+              first(LuxCore.apply(model, x, ps, st))
 
         @test_nowarn println(model)
 
@@ -110,7 +110,7 @@ end
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
         @test LuxCore.stateless_apply(model, x, ps) ==
-              first(LuxCore.apply(model, x, ps, NamedTuple()))
+              first(LuxCore.apply(model, x, ps, st))
 
         @test_nowarn println(model)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,9 @@ end
 
             @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
+            @test LuxCore.stateless_apply(model, x, ps, st) ==
+                  first(LuxCore.apply(model, x, ps, st))
+
             @test_nowarn println(model)
         end
 
@@ -88,6 +91,9 @@ end
 
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
 
+        @test LuxCore.stateless_apply(model, x, ps, st) ==
+              first(LuxCore.apply(model, x, ps, st))
+
         @test_nowarn println(model)
 
         model = Chain2(Dense(5, 5), Dense(5, 6))
@@ -102,6 +108,9 @@ end
               LuxCore.statelength(model.layer1) + LuxCore.statelength(model.layer2)
 
         @test LuxCore.apply(model, x, ps, st) == model(x, ps, st)
+
+        @test LuxCore.stateless_apply(model, x, ps, st) ==
+              first(LuxCore.apply(model, x, ps, st))
 
         @test_nowarn println(model)
     end


### PR DESCRIPTION
This PR adds a small function, `partial_apply`, which is needed to implement an extension in Symbolics for LuxCore (see https://github.com/JuliaSymbolics/Symbolics.jl/pull/1054), allowing the registration of the application of the layer as a vectror function. The important aspect here is that we need the size of the return type of the function, which is why we only return the first argument from `apply`.

Let me know what you think about this approach.

cc @ChrisRackauckas

Edit: renamed to `stateless_apply`.