### PR TITLE
Add input and output size functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -94,6 +94,20 @@ statelength(a::AbstractArray) = length(a)
 statelength(::Any) = 1
 
 """
+    inputsize(layer)
+
+Return the input size of the layer.
+"""
+function inputsize end
+
+"""
+    outputsize(layer)
+
+Return the output size of the layer.
+"""
+function outputsize end
+
+"""
     setup(rng::AbstractRNG, layer)
 
 Shorthand for getting the parameters and states of the layer `l`. Is equivalent to


### PR DESCRIPTION
This PR adds a generic interfacce for input and output sizes for layers.

A followup PR in Lux will do concrete implementations for the layers.