### PR TITLE
make `outputsize` more generic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -99,6 +99,14 @@ statelength(a::AbstractArray) = length(a)
 statelength(::Any) = 1
 
 """
+    has_static_outputsize(layer)
+
+
+Specify if the `outputsize` can be computed only from the layer definition.
+"""
+has_static_outputsize(layer) = Val(false)
+
+"""
     inputsize(layer)
 
 Return the input size of the layer.
@@ -106,11 +114,23 @@ Return the input size of the layer.
 function inputsize end
 
 """
-    outputsize(layer)
+    outputsize(layer, x, rng)
 
-Return the output size of the layer.
+
+Return the output size of the layer. If the output size can be statically determined
+(see [`has_static_outputsize`](@ref)), one can also use `outputsize(layer)` directly.
 """
-function outputsize end
+outputsize(layer, x, rng) = outputsize(has_static_outputsize(layer), x, rng)
+
+function outputsize(::Val{true}, x, rng)
+    outputsize(layer)
+end
+
+function outputsize(::Val{false}, x, rng)
+    ps, st = Lux.setup(rng, layer)
+    y = first(layer(x, ps, st))
+    size(y)
+end
 
 """
     setup(rng::AbstractRNG, layer)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -101,7 +101,6 @@ statelength(::Any) = 1
 """
     has_static_outputsize(layer)
 
-
 Specify if the `outputsize` can be computed only from the layer definition.
 """
 has_static_outputsize(layer) = hasmethod(outputsize, Tuple{Any})
@@ -121,20 +120,19 @@ __size(x) = fmap(__size, x)
 """
     outputsize(layer, x, rng)
 
-
 Return the output size of the layer. If `outputsize(layer)` is defined, that method
 takes precedence, else we compute the layer output to determine the final size.
 """
 outputsize(layer, x, rng) = outputsize(has_static_outputsize(layer), x, rng)
 
 function outputsize(::Val{true}, x, rng)
-    outputsize(layer)
+    return outputsize(layer)
 end
 
 function outputsize(::Val{false}, x, rng)
     ps, st = Lux.setup(rng, layer)
     y = first(layer(x, ps, st))
-    __size(y)
+    return __size(y)
 end
 
 """

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -117,8 +117,8 @@ function inputsize end
     outputsize(layer, x, rng)
 
 
-Return the output size of the layer. If the output size can be statically determined
-(see [`has_static_outputsize`](@ref)), one can also use `outputsize(layer)` directly.
+Return the output size of the layer. If `outputsize(layer)` is defined, that method
+takes precedence, else we compute the layer output to determine the final size.
 """
 outputsize(layer, x, rng) = outputsize(has_static_outputsize(layer), x, rng)
 

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -120,15 +120,7 @@ Return the output size of the layer. If `outputsize(layer)` is defined, that met
 takes precedence, else we compute the layer output to determine the final size.
 """
 function outputsize(layer, x, rng)
-    has_static_outputsize = hasmethod(outputsize, Tuple{typeof(layer)})
-    return outputsize(Val(has_static_outputsize), layer, x, rng)
-end
-
-function outputsize(::Val{true}, layer, x, rng)
-    return outputsize(layer)
-end
-
-function outputsize(::Val{false}, layer, x, rng)
+    hasmethod(outputsize, Tuple{typeof(layer)}) && return outputsize(layer)
     ps, st = LuxCore.setup(rng, layer)
     y = first(apply(layer, x, ps, st))
     return __size(y)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -104,7 +104,7 @@ statelength(::Any) = 1
 
 Specify if the `outputsize` can be computed only from the layer definition.
 """
-has_static_outputsize(layer) = Val(false)
+has_static_outputsize(layer) = hasmethod(outputsize, Tuple{Any})
 
 """
     inputsize(layer)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -113,6 +113,11 @@ Return the input size of the layer.
 """
 function inputsize end
 
+__size(x::AbstractArray{T, N}) where {T} = isbitstype(T) ? size(x)[1:(N - 1)] : __size.(x)
+__size(x::Tuple) = __size.(x)
+__size(x::NamedTuple{fields}) where {fields} = NamedTuple{fields}(__size.(values(x)))
+__size(x) = fmap(__size, x)
+
 """
     outputsize(layer, x, rng)
 
@@ -129,7 +134,7 @@ end
 function outputsize(::Val{false}, x, rng)
     ps, st = Lux.setup(rng, layer)
     y = first(layer(x, ps, st))
-    size(y)
+    __size(y)
 end
 
 """

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -99,13 +99,6 @@ statelength(a::AbstractArray) = length(a)
 statelength(::Any) = 1
 
 """
-    has_static_outputsize(layer)
-
-Specify if the `outputsize` can be computed only from the layer definition.
-"""
-has_static_outputsize(layer) = hasmethod(outputsize, Tuple{Any})
-
-"""
     inputsize(layer)
 
 Return the input size of the layer.
@@ -126,7 +119,10 @@ __size(x) = fmap(__size, x)
 Return the output size of the layer. If `outputsize(layer)` is defined, that method
 takes precedence, else we compute the layer output to determine the final size.
 """
-outputsize(layer, x, rng) = outputsize(Val(has_static_outputsize(layer)), layer, x, rng)
+function outputsize(layer, x, rng)
+    has_static_outputsize = hasmethod(outputsize, Tuple{typeof(layer)})
+    return outputsize(Val(has_static_outputsize), layer, x, rng)
+end
 
 function outputsize(::Val{true}, layer, x, rng)
     return outputsize(layer)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -118,7 +118,11 @@ __size(x) = fmap(__size, x)
 
 Return the output size of the layer. If `outputsize(layer)` is defined, that method
 takes precedence, else we compute the layer output to determine the final size.
-"""
+
+The fallback implementation of this function assumes the inputs were batched, i.e.,
+if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
+`size(A)[1:(end - 1)]`. If this behavior is undesirable, provide a custom
+`outputsize(layer, x, rng)` implementation).
 function outputsize(layer, x, rng)
     hasmethod(outputsize, Tuple{typeof(layer)}) && return outputsize(layer)
     ps, st = LuxCore.setup(rng, layer)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -123,6 +123,7 @@ The fallback implementation of this function assumes the inputs were batched, i.
 if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
 `size(A)[1:(end - 1)]`. If this behavior is undesirable, provide a custom
 `outputsize(layer, x, rng)` implementation).
+"""
 function outputsize(layer, x, rng)
     hasmethod(outputsize, Tuple{typeof(layer)}) && return outputsize(layer)
     ps, st = LuxCore.setup(rng, layer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,8 @@ end
             @test LuxCore.stateless_apply(model, x, ps) ==
                   first(LuxCore.apply(model, x, ps, NamedTuple()))
 
+            # the layer just passes x along
+            @test LuxCore.outputsize(model, x, rng) == (5,)
             @test_nowarn println(model)
         end
 
@@ -112,6 +114,9 @@ end
         @test LuxCore.stateless_apply(model, x, ps) ==
               first(LuxCore.apply(model, x, ps, st))
 
+        # the layers just pass x along
+        @test LuxCore.outputsize(model, x, rng) == (5,)
+
         @test_nowarn println(model)
     end
 
@@ -166,6 +171,8 @@ end
             @test new_model.layers.layer_1.out == 5
             @test new_model.layers.layer_2.in == 5
             @test new_model.layers.layer_2.out == 10
+
+            @test LuxCore.outputsize(model, rand(5), rng) == (5,)
         end
 
         @testset "Method Ambiguity" begin


### PR DESCRIPTION
I'm not sure how to handle the case where the output is not an array, do we expect `size` to not work too?