### PR TITLE
Change internal default rng

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.16"
+version = "0.1.17"
 
 [deps]
 Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -1,7 +1,7 @@
 module LuxCore
 
 using Functors: Functors, fmap
-using Random: Random, AbstractRNG
+using Random: Random, AbstractRNG, Xoshiro
 using Setfield: Setfield
 
 # PRNG Handling
@@ -16,11 +16,7 @@ function replicate(rng::Random.TaskLocalRNG)
     return deepcopy(rng)
 end
 
-function _default_rng()
-    rng = Random.default_rng()
-    Random.seed!(rng, 1234)
-    return rng
-end
+@inline _default_rng() = Xoshiro(1234)
 
 """
     abstract type AbstractExplicitLayer


### PR DESCRIPTION
`replicate` shows a warning on being used with `TaskLocalRNG` since we can't safely copy that. This exposes mostly an internal implementation detail.