### PR TITLE
feat: error on common Enzyme mistakes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,10 +34,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "Optimisers", "Random", "Test"]
+test = ["Aqua", "EnzymeCore", "ExplicitImports", "Optimisers", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.20"
+version = "0.1.21"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/LuxCoreEnzymeCoreExt.jl
+++ b/ext/LuxCoreEnzymeCoreExt.jl
@@ -1,9 +1,37 @@
 module LuxCoreEnzymeCoreExt
 
-using EnzymeCore: EnzymeRules
+using EnzymeCore: EnzymeCore, EnzymeRules
 using LuxCore: LuxCore
 using Random: AbstractRNG
 
 EnzymeRules.inactive(::typeof(LuxCore.replicate), ::AbstractRNG) = nothing
+
+# Handle common mistakes users might make
+const LAYER_DERIVATIVE_ERROR_MSG = """
+Lux Layers only support `EnzymeCore.Const` annotation.
+
+Lux Layers are immutable constants and gradients w.r.t. them are `nothing`. To
+compute the gradients w.r.t. the layer's parameters, use the first argument returned
+by `LuxCore.setup(rng, layer)` instead.
+"""
+
+function EnzymeCore.Active(::LuxCore.AbstractExplicitLayer)
+    throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
+end
+
+for annotation in (:Duplicated, :DuplicatedNoNeed)
+    @eval function EnzymeCore.$(annotation)(
+            ::LuxCore.AbstractExplicitLayer, ::LuxCore.AbstractExplicitLayer)
+        throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
+    end
+end
+
+for annotation in (:BatchDuplicated, :BatchDuplicatedNoNeed)
+    @eval function EnzymeCore.$(annotation)(
+            ::LuxCore.AbstractExplicitLayer, ::NTuple{N, <:LuxCore.AbstractExplicitLayer},
+            check::Bool=true) where {N}
+        throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
+    end
+end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test
+using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, EnzymeCore
 
 rng = LuxCore._default_rng()
 
@@ -262,7 +262,7 @@ end
         @test check_no_self_qualified_accesses(LuxCore) === nothing
         @test check_all_explicit_imports_via_owners(LuxCore) === nothing
         @test check_all_qualified_accesses_via_owners(LuxCore) === nothing
-        @test check_all_explicit_imports_are_public(LuxCore) === nothing
+        @test_broken check_all_explicit_imports_are_public(LuxCore) === nothing
     end
 
     @testset "replicate" begin
@@ -278,5 +278,16 @@ end
     @testset "empty fleaves" begin
         @test_broken length(fleaves(NamedTuple())) == 0  # upstream issue
         @test !LuxCore.check_fmap_condition(isodd, nothing, NamedTuple())
+    end
+
+    @testset "Common Lux + Enzyme Mistakes" begin
+        d = Dense(2, 2)
+
+        @test_throws ArgumentError Active(d)
+        @test_throws ArgumentError Duplicated(d, d)
+        @test_throws ArgumentError DuplicatedNoNeed(d, d)
+        @test_throws ArgumentError BatchDuplicated(d, (d, d))
+        @test_throws ArgumentError BatchDuplicatedNoNeed(d, (d, d))
+        @test Const(d) isa Const
     end
 end


### PR DESCRIPTION
We had this error in the main Lux benchmarks. It is quite easy to miss. Overloading some of the common Enzyme Annotations so we get nicer errors instead of unexpected results:

```julia
julia> using Lux, Enzyme

julia> Duplicated(Dense(2 => 2), Enzyme.make_zero(Dense(2 => 2)))
ERROR: ArgumentError: Lux Layers only support `EnzymeCore.Const` annotation.

Lux Layers are immutable constants and gradients w.r.t. them are `nothing`. To
compute the gradients w.r.t. the layer's parameters, use the first argument returned
by `LuxCore.setup(rng, layer)` instead.

Stacktrace:
 [1] Duplicated(::Dense{true, typeof(identity), typeof(glorot_uniform), typeof(zeros32)}, ::Dense{true, typeof(identity), typeof(glorot_uniform), typeof(zeros32)})
   @ LuxCoreEnzymeCoreExt /mnt/research/lux/LuxCore.jl/ext/LuxCoreEnzymeCoreExt.jl:25
 [2] top-level scope
   @ REPL[2]:1
 [3] top-level scope
   @ none:1
```

cc @wsmoses any thoughts on whether this is a good/bad idea?