### PR TITLE
refactor: deprecate `Explicit` in favor of `Lux`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.24"
+version = "0.1.25"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
+++ b/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
@@ -1,15 +1,15 @@
 module LuxCoreArrayInterfaceReverseDiffExt
 
 using ArrayInterface: ArrayInterface
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using ReverseDiff: TrackedReal, TrackedArray
 
 # AoS to SoA conversion
 function LuxCore.apply(
-        m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}, ps, st)
-    @warn "Lux.apply(m::AbstractExplicitLayer, \
+        m::AbstractLuxLayer, x::AbstractArray{<:TrackedReal}, ps, st)
+    @warn "Lux.apply(m::AbstractLuxLayer, \
            x::AbstractArray{<:ReverseDiff.TrackedReal}, ps, st) input was corrected to \
-           Lux.apply(m::AbstractExplicitLayer, x::ReverseDiff.TrackedArray}, ps, \
+           Lux.apply(m::AbstractLuxLayer, x::ReverseDiff.TrackedArray}, ps, \
            st).\n\n\
         1. If this was not the desired behavior overload the dispatch on `m`.\n\n\
         2. This might have performance implications. Check which layer was causing this \
@@ -18,6 +18,6 @@ function LuxCore.apply(
 end
 
 ## Prevent an infinite loop
-LuxCore.apply(m::AbstractExplicitLayer, x::TrackedArray, ps, st) = m(x, ps, st)
+LuxCore.apply(m::AbstractLuxLayer, x::TrackedArray, ps, st) = m(x, ps, st)
 
 end

--- a/ext/LuxCoreArrayInterfaceTrackerExt.jl
+++ b/ext/LuxCoreArrayInterfaceTrackerExt.jl
@@ -1,14 +1,14 @@
 module LuxCoreArrayInterfaceTrackerExt
 
 using ArrayInterface: ArrayInterface
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using Tracker: TrackedReal, TrackedArray
 
 # AoS to SoA conversion
-function LuxCore.apply(m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}, ps, st)
-    @warn "LuxCore.apply(m::AbstractExplicitLayer, \
+function LuxCore.apply(m::AbstractLuxLayer, x::AbstractArray{<:TrackedReal}, ps, st)
+    @warn "LuxCore.apply(m::AbstractLuxLayer, \
            x::AbstractArray{<:Tracker.TrackedReal}, ps, st) input was corrected to \
-           LuxCore.apply(m::AbstractExplicitLayer, x::Tracker.TrackedArray}, ps, st).\n\n\
+           LuxCore.apply(m::AbstractLuxLayer, x::Tracker.TrackedArray}, ps, st).\n\n\
            1. If this was not the desired behavior overload the dispatch on `m`.\n\n\
            2. This might have performance implications. Check which layer was causing this \
               problem using `Lux.Experimental.@debug_mode`." maxlog=1
@@ -16,6 +16,6 @@ function LuxCore.apply(m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}
 end
 
 ## Prevent an infinite loop
-LuxCore.apply(m::AbstractExplicitLayer, x::TrackedArray, ps, st) = m(x, ps, st)
+LuxCore.apply(m::AbstractLuxLayer, x::TrackedArray, ps, st) = m(x, ps, st)
 
 end

--- a/ext/LuxCoreChainRulesCoreExt.jl
+++ b/ext/LuxCoreChainRulesCoreExt.jl
@@ -1,12 +1,12 @@
 module LuxCoreChainRulesCoreExt
 
 using ChainRulesCore: ChainRulesCore, @non_differentiable
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using Random: AbstractRNG
 
 @non_differentiable LuxCore.replicate(::AbstractRNG)
 
-function ChainRulesCore.rrule(::typeof(getproperty), m::AbstractExplicitLayer, x::Symbol)
+function ChainRulesCore.rrule(::typeof(getproperty), m::AbstractLuxLayer, x::Symbol)
     mₓ = getproperty(m, x)
     ∇getproperty(_) = ntuple(Returns(ChainRulesCore.NoTangent()), 3)
     return mₓ, ∇getproperty

--- a/ext/LuxCoreEnzymeCoreExt.jl
+++ b/ext/LuxCoreEnzymeCoreExt.jl
@@ -15,20 +15,20 @@ compute the gradients w.r.t. the layer's parameters, use the first argument retu
 by `LuxCore.setup(rng, layer)` instead.
 """
 
-function EnzymeCore.Active(::LuxCore.AbstractExplicitLayer)
+function EnzymeCore.Active(::LuxCore.AbstractLuxLayer)
     throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
 end
 
 for annotation in (:Duplicated, :DuplicatedNoNeed)
     @eval function EnzymeCore.$(annotation)(
-            ::LuxCore.AbstractExplicitLayer, ::LuxCore.AbstractExplicitLayer)
+            ::LuxCore.AbstractLuxLayer, ::LuxCore.AbstractLuxLayer)
         throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
     end
 end
 
 for annotation in (:BatchDuplicated, :BatchDuplicatedNoNeed)
     @eval function EnzymeCore.$(annotation)(
-            ::LuxCore.AbstractExplicitLayer, ::NTuple{N, <:LuxCore.AbstractExplicitLayer},
+            ::LuxCore.AbstractLuxLayer, ::NTuple{N, <:LuxCore.AbstractLuxLayer},
             check::Bool=true) where {N}
         throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
     end

--- a/ext/LuxCoreMLDataDevicesExt.jl
+++ b/ext/LuxCoreMLDataDevicesExt.jl
@@ -5,7 +5,7 @@ using MLDataDevices: MLDataDevices
 
 for (dev) in (:CPU, :CUDA, :AMDGPU, :Metal, :oneAPI)
     ldev = Symbol(dev, :Device)
-    @eval function (::MLDataDevices.$(ldev))(NN::LuxCore.AbstractExplicitLayer)
+    @eval function (::MLDataDevices.$(ldev))(NN::LuxCore.AbstractLuxLayer)
         @warn "Lux layers are stateless and hence don't participate in device transfers. \
                Apply this function on the parameters and states generated using \
                `LuxCore.setup`."

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -24,29 +24,29 @@ end
 _default_rng() = Xoshiro(1234)
 
 """
-    abstract type AbstractExplicitLayer
+    abstract type AbstractLuxLayer
 
 Abstract Type for all Lux Layers
 
 Users implementing their custom layer, **must** implement
 
-  - `initialparameters(rng::AbstractRNG, layer::CustomAbstractExplicitLayer)` -- This
+  - `initialparameters(rng::AbstractRNG, layer::CustomAbstractLuxLayer)` -- This
     returns a `NamedTuple` containing the trainable parameters for the layer.
-  - `initialstates(rng::AbstractRNG, layer::CustomAbstractExplicitLayer)` -- This returns a
+  - `initialstates(rng::AbstractRNG, layer::CustomAbstractLuxLayer)` -- This returns a
     NamedTuple containing the current state for the layer. For most layers this is typically
     empty. Layers that would potentially contain this include `BatchNorm`, `LSTM`, `GRU`,
     etc.
 
 Optionally:
 
-  - `parameterlength(layer::CustomAbstractExplicitLayer)` -- These can be automatically
+  - `parameterlength(layer::CustomAbstractLuxLayer)` -- These can be automatically
     calculated, but it is recommended that the user defines these.
-  - `statelength(layer::CustomAbstractExplicitLayer)` -- These can be automatically
+  - `statelength(layer::CustomAbstractLuxLayer)` -- These can be automatically
     calculated, but it is recommended that the user defines these.
 
-See also [`AbstractExplicitContainerLayer`](@ref)
+See also [`AbstractLuxContainerLayer`](@ref)
 """
-abstract type AbstractExplicitLayer end
+abstract type AbstractLuxLayer end
 
 """
     initialparameters(rng::AbstractRNG, layer)
@@ -64,7 +64,7 @@ function initialstates end
 
 for op in (:initialparameters, :initialstates)
     @eval begin
-        $(op)(::AbstractRNG, ::Union{AbstractExplicitLayer, Nothing}) = NamedTuple()
+        $(op)(::AbstractRNG, ::Union{AbstractLuxLayer, Nothing}) = NamedTuple()
         $(op)(rng::AbstractRNG, l::NamedTuple) = map(Base.Fix1($op, rng), l)
         function $(op)(rng::AbstractRNG, l)
             contains_lux_layer(l) && return fmap(Base.Fix1($op, rng), l; exclude=_fmap_leaf)
@@ -73,10 +73,10 @@ for op in (:initialparameters, :initialstates)
     end
 end
 
-_fmap_leaf(::AbstractExplicitLayer) = true
+_fmap_leaf(::AbstractLuxLayer) = true
 _fmap_leaf(x) = Functors.isleaf(x)
 
-_getemptystate(::AbstractExplicitLayer) = NamedTuple()
+_getemptystate(::AbstractLuxLayer) = NamedTuple()
 _getemptystate(l::NamedTuple) = map(_getemptystate, l)
 
 """
@@ -84,7 +84,7 @@ _getemptystate(l::NamedTuple) = map(_getemptystate, l)
 
 Return the total number of parameters of the layer `l`.
 """
-function parameterlength(l::AbstractExplicitLayer)
+function parameterlength(l::AbstractLuxLayer)
     return parameterlength(initialparameters(_default_rng(), l))
 end
 function parameterlength(nt::Union{NamedTuple, Tuple})
@@ -97,7 +97,7 @@ parameterlength(a::AbstractArray) = length(a)
 
 Return the total number of states of the layer `l`.
 """
-statelength(l::AbstractExplicitLayer) = statelength(initialstates(_default_rng(), l))
+statelength(l::AbstractLuxLayer) = statelength(initialstates(_default_rng(), l))
 statelength(nt::Union{NamedTuple, Tuple}) = length(nt) == 0 ? 0 : sum(statelength, nt)
 statelength(a::AbstractArray) = length(a)
 statelength(::Any) = 1
@@ -167,7 +167,7 @@ this include:
     type stability. By default this is "disable"d. For more information, see the
     [documentation](https://github.com/MilesCranmer/DispatchDoctor.jl).
 """
-@stable default_mode="disable" function apply(model::AbstractExplicitLayer, x, ps, st)
+@stable default_mode="disable" function apply(model::AbstractLuxLayer, x, ps, st)
     return model(x, ps, st)
 end
 
@@ -178,17 +178,17 @@ Calls `apply` and only returns the first argument. This function requires that `
 an empty state of `NamedTuple()`. Behavior of other kinds of models are undefined and it is
 the responsibility of the user to ensure that the model has an empty state.
 """
-function stateless_apply(model::AbstractExplicitLayer, x, ps)
+function stateless_apply(model::AbstractLuxLayer, x, ps)
     return first(apply(model, x, ps, _getemptystate(model)))
 end
 
 """
-    display_name(layer::AbstractExplicitLayer)
+    display_name(layer::AbstractLuxLayer)
 
 Printed Name of the `layer`. If the `layer` has a field `name` that is used, else the type
 name is used.
 """
-@generated function display_name(l::L) where {L <: AbstractExplicitLayer}
+@generated function display_name(l::L) where {L <: AbstractLuxLayer}
     hasfield(L, :name) &&
         return :(ifelse(l.name === nothing, $(string(nameof(L))), string(l.name)))
     return :($(string(nameof(L))))
@@ -197,13 +197,13 @@ display_name(::T) where {T} = string(nameof(T))
 
 # Abstract Container Layers
 """
-    abstract type AbstractExplicitContainerLayer{layers} <: AbstractExplicitLayer
+    abstract type AbstractLuxContainerLayer{layers} <: AbstractLuxLayer
 
 Abstract Container Type for certain Lux Layers. `layers` is a tuple containing fieldnames
 for the layer, and constructs the parameters and states using those.
 
 Users implementing their custom layer can extend the same functions as in
-[`AbstractExplicitLayer`](@ref).
+[`AbstractLuxLayer`](@ref).
 
 !!! tip
 
@@ -211,37 +211,37 @@ Users implementing their custom layer can extend the same functions as in
     `Functors.fmap`. For a more flexible interface, we recommend using
     `Lux.Experimental.@layer_map`.
 """
-abstract type AbstractExplicitContainerLayer{layers} <: AbstractExplicitLayer end
+abstract type AbstractLuxContainerLayer{layers} <: AbstractLuxLayer end
 
 function initialparameters(rng::AbstractRNG,
-        l::AbstractExplicitContainerLayer{layers}) where {layers}
+        l::AbstractLuxContainerLayer{layers}) where {layers}
     length(layers) == 1 && return initialparameters(rng, getfield(l, layers[1]))
     return NamedTuple{layers}(initialparameters.(rng, getfield.((l,), layers)))
 end
 
 function initialstates(rng::AbstractRNG,
-        l::AbstractExplicitContainerLayer{layers}) where {layers}
+        l::AbstractLuxContainerLayer{layers}) where {layers}
     length(layers) == 1 && return initialstates(rng, getfield(l, layers[1]))
     return NamedTuple{layers}(initialstates.(rng, getfield.((l,), layers)))
 end
 
-function parameterlength(l::AbstractExplicitContainerLayer{layers}) where {layers}
+function parameterlength(l::AbstractLuxContainerLayer{layers}) where {layers}
     return sum(parameterlength, getfield.((l,), layers))
 end
 
-function statelength(l::AbstractExplicitContainerLayer{layers}) where {layers}
+function statelength(l::AbstractLuxContainerLayer{layers}) where {layers}
     return sum(statelength, getfield.((l,), layers))
 end
 
-_fmap_leaf(::AbstractExplicitContainerLayer) = true
+_fmap_leaf(::AbstractLuxContainerLayer) = true
 
-function _getemptystate(l::AbstractExplicitContainerLayer{layers}) where {layers}
+function _getemptystate(l::AbstractLuxContainerLayer{layers}) where {layers}
     length(layers) == 1 && return _getemptystate(getfield(l, first(layers)))
     return NamedTuple{layers}(_getemptystate.(getfield.((l,), layers)))
 end
 
 # Make AbstractExplicit Layers Functor Compatible
-function Functors.functor(::Type{<:AbstractExplicitContainerLayer{layers}},
+function Functors.functor(::Type{<:AbstractLuxContainerLayer{layers}},
         x) where {layers}
     _children = NamedTuple{layers}(getproperty.((x,), layers))
     recon_fn = (l, (c, n)) -> Setfield.set(l, Setfield.PropertyLens{n}(), c)
@@ -289,11 +289,11 @@ end
 """
     contains_lux_layer(l) -> Bool
 
-Check if the structure `l` is a Lux AbstractExplicitLayer or a container of such a layer.
+Check if the structure `l` is a Lux AbstractLuxLayer or a container of such a layer.
 """
 function contains_lux_layer(l)
-    return check_fmap_condition(Base.Fix2(isa, AbstractExplicitLayer),
-        AbstractExplicitLayer, l)
+    return check_fmap_condition(Base.Fix2(isa, AbstractLuxLayer),
+        AbstractLuxLayer, l)
 end
 
 """
@@ -319,9 +319,12 @@ function check_fmap_condition(cond::C, ::Type{T}, x) where {C, T}
     return check_fmap_condition(cond, nothing, x)
 end
 
+Base.@deprecate_binding AbstractExplicitLayer AbstractLuxLayer false
+Base.@deprecate_binding AbstractExplicitContainerLayer AbstractLuxContainerLayer false
+
 @compat(public,
     (replicate, trainmode, testmode, update_state, contains_lux_layer,
-        check_fmap_condition, AbstractExplicitLayer, AbstractExplicitContainerLayer,
+        check_fmap_condition, AbstractLuxLayer, AbstractLuxContainerLayer,
         initialparameters, initialstates, parameterlength, statelength,
         inputsize, outputsize, setup, apply, stateless_apply, display_name))
 

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -125,7 +125,12 @@ if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
 `outputsize(layer, x, rng)` implementation).
 """
 function outputsize(layer, x, rng)
-    hasmethod(outputsize, Tuple{typeof(layer)}) && return outputsize(layer)
+    if hasmethod(outputsize, Tuple{typeof(layer)})
+        Base.depwarn(
+            "`outputsize(layer)` is deprecated, use `outputsize(layer, x, rng)` instead",
+            :outputsize)
+        return outputsize(layer)
+    end
     ps, st = setup(rng, layer)
     y = first(apply(layer, x, ps, st))
     return __size(y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, Enzyme
 rng = LuxCore._default_rng()
 
 # Define some custom layers
-struct Dense <: LuxCore.AbstractExplicitLayer
+struct Dense <: LuxCore.AbstractLuxLayer
     in::Int
     out::Int
 end
@@ -15,7 +15,7 @@ end
 
 (::Dense)(x, ps, st) = x, st  # Dummy Forward Pass
 
-struct Chain{L} <: LuxCore.AbstractExplicitContainerLayer{(:layers,)}
+struct Chain{L} <: LuxCore.AbstractLuxContainerLayer{(:layers,)}
     layers::L
 end
 
@@ -25,7 +25,7 @@ function (c::Chain)(x, ps, st)
     return y, (layers = (st1, st2))
 end
 
-struct Chain2{L1, L2} <: LuxCore.AbstractExplicitContainerLayer{(:layer1, :layer2)}
+struct Chain2{L1, L2} <: LuxCore.AbstractLuxContainerLayer{(:layer1, :layer2)}
     layer1::L1
     layer2::L2
 end
@@ -37,7 +37,7 @@ function (c::Chain2)(x, ps, st)
 end
 
 @testset "LuxCore.jl Tests" begin
-    @testset "AbstractExplicitLayer Interface" begin
+    @testset "AbstractLuxLayer Interface" begin
         @testset "Custom Layer" begin
             model = Dense(5, 6)
             x = randn(rng, Float32, 5)
@@ -57,7 +57,7 @@ end
         end
 
         @testset "Default Fallbacks" begin
-            struct NoParamStateLayer <: LuxCore.AbstractExplicitLayer end
+            struct NoParamStateLayer <: LuxCore.AbstractLuxLayer end
 
             layer = NoParamStateLayer()
             @test LuxCore.initialparameters(rng, layer) == NamedTuple()
@@ -83,7 +83,7 @@ end
         end
     end
 
-    @testset "AbstractExplicitContainerLayer Interface" begin
+    @testset "AbstractLuxContainerLayer Interface" begin
         model = Chain((; layer_1=Dense(5, 5), layer_2=Dense(5, 6)))
         x = randn(rng, Float32, 5)
         ps, st = LuxCore.setup(rng, model)
@@ -184,7 +184,7 @@ end
         @testset "Method Ambiguity" begin
             # Needed if defining a layer that works with both Flux and Lux -- See DiffEqFlux.jl
             # See https://github.com/SciML/DiffEqFlux.jl/pull/750#issuecomment-1373874944
-            struct CustomLayer{M, P} <: LuxCore.AbstractExplicitContainerLayer{(:model,)}
+            struct CustomLayer{M, P} <: LuxCore.AbstractLuxContainerLayer{(:model,)}
                 model::M
                 p::P
             end
@@ -198,13 +198,13 @@ end
     end
 
     @testset "Display Name" begin
-        struct StructWithoutName <: LuxCore.AbstractExplicitLayer end
+        struct StructWithoutName <: LuxCore.AbstractLuxLayer end
 
         model = StructWithoutName()
 
         @test LuxCore.display_name(model) == "StructWithoutName"
 
-        struct StructWithName{N} <: LuxCore.AbstractExplicitLayer
+        struct StructWithName{N} <: LuxCore.AbstractLuxLayer
             name::N
         end
 


### PR DESCRIPTION
This will be a bridge PR between 0.1 and 1.0 to allow people to see the deprecation warning before updating their code.