### PR TITLE
feat!: 1.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,9 +6,7 @@ version = "1.0.0-DEV"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
-Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 
 [weakdeps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -22,8 +20,10 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 LuxCoreArrayInterfaceReverseDiffExt = ["ArrayInterface", "ReverseDiff"]
 LuxCoreArrayInterfaceTrackerExt = ["ArrayInterface", "Tracker"]
 LuxCoreChainRulesCoreExt = "ChainRulesCore"
-LuxCoreEnzymeCoreExt = "EnzymeCore"
+LuxCoreFunctorsExt = "Functors"
 LuxCoreMLDataDevicesExt = "MLDataDevices"
+LuxCoreEnzymeCoreExt = "EnzymeCore"
+LuxCoreSetfieldExt = "Setfield"
 
 [compat]
 ArrayInterface = "7.9"

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,10 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [extensions]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "0.1.25"
+version = "1.0.0-DEV"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LuxCore"
 uuid = "bb33d45b-7691-41d6-9220-0943567d0623"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.0.0-DEV"
+version = "1.0.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -22,9 +22,9 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 LuxCoreArrayInterfaceReverseDiffExt = ["ArrayInterface", "ReverseDiff"]
 LuxCoreArrayInterfaceTrackerExt = ["ArrayInterface", "Tracker"]
 LuxCoreChainRulesCoreExt = "ChainRulesCore"
+LuxCoreEnzymeCoreExt = "EnzymeCore"
 LuxCoreFunctorsExt = "Functors"
 LuxCoreMLDataDevicesExt = "MLDataDevices"
-LuxCoreEnzymeCoreExt = "EnzymeCore"
 LuxCoreSetfieldExt = "Setfield"
 
 [compat]

--- a/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
+++ b/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
@@ -9,8 +9,7 @@ function LuxCore.apply(
         m::AbstractLuxLayer, x::AbstractArray{<:TrackedReal}, ps, st)
     @warn "Lux.apply(m::AbstractLuxLayer, \
            x::AbstractArray{<:ReverseDiff.TrackedReal}, ps, st) input was corrected to \
-           Lux.apply(m::AbstractLuxLayer, x::ReverseDiff.TrackedArray}, ps, \
-           st).\n\n\
+           Lux.apply(m::AbstractLuxLayer, x::ReverseDiff.TrackedArray}, ps, st).\n\n\
         1. If this was not the desired behavior overload the dispatch on `m`.\n\n\
         2. This might have performance implications. Check which layer was causing this \
            problem using `Lux.Experimental.@debug_mode`." maxlog=1

--- a/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
+++ b/ext/LuxCoreArrayInterfaceReverseDiffExt.jl
@@ -1,15 +1,15 @@
 module LuxCoreArrayInterfaceReverseDiffExt
 
 using ArrayInterface: ArrayInterface
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using ReverseDiff: TrackedReal, TrackedArray
 
 # AoS to SoA conversion
 function LuxCore.apply(
-        m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}, ps, st)
-    @warn "Lux.apply(m::AbstractExplicitLayer, \
+        m::AbstractLuxLayer, x::AbstractArray{<:TrackedReal}, ps, st)
+    @warn "Lux.apply(m::AbstractLuxLayer, \
            x::AbstractArray{<:ReverseDiff.TrackedReal}, ps, st) input was corrected to \
-           Lux.apply(m::AbstractExplicitLayer, x::ReverseDiff.TrackedArray}, ps, \
+           Lux.apply(m::AbstractLuxLayer, x::ReverseDiff.TrackedArray}, ps, \
            st).\n\n\
         1. If this was not the desired behavior overload the dispatch on `m`.\n\n\
         2. This might have performance implications. Check which layer was causing this \
@@ -18,6 +18,6 @@ function LuxCore.apply(
 end
 
 ## Prevent an infinite loop
-LuxCore.apply(m::AbstractExplicitLayer, x::TrackedArray, ps, st) = m(x, ps, st)
+LuxCore.apply(m::AbstractLuxLayer, x::TrackedArray, ps, st) = m(x, ps, st)
 
 end

--- a/ext/LuxCoreArrayInterfaceTrackerExt.jl
+++ b/ext/LuxCoreArrayInterfaceTrackerExt.jl
@@ -1,14 +1,14 @@
 module LuxCoreArrayInterfaceTrackerExt
 
 using ArrayInterface: ArrayInterface
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using Tracker: TrackedReal, TrackedArray
 
 # AoS to SoA conversion
-function LuxCore.apply(m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}, ps, st)
-    @warn "LuxCore.apply(m::AbstractExplicitLayer, \
+function LuxCore.apply(m::AbstractLuxLayer, x::AbstractArray{<:TrackedReal}, ps, st)
+    @warn "LuxCore.apply(m::AbstractLuxLayer, \
            x::AbstractArray{<:Tracker.TrackedReal}, ps, st) input was corrected to \
-           LuxCore.apply(m::AbstractExplicitLayer, x::Tracker.TrackedArray}, ps, st).\n\n\
+           LuxCore.apply(m::AbstractLuxLayer, x::Tracker.TrackedArray}, ps, st).\n\n\
            1. If this was not the desired behavior overload the dispatch on `m`.\n\n\
            2. This might have performance implications. Check which layer was causing this \
               problem using `Lux.Experimental.@debug_mode`." maxlog=1
@@ -16,6 +16,6 @@ function LuxCore.apply(m::AbstractExplicitLayer, x::AbstractArray{<:TrackedReal}
 end
 
 ## Prevent an infinite loop
-LuxCore.apply(m::AbstractExplicitLayer, x::TrackedArray, ps, st) = m(x, ps, st)
+LuxCore.apply(m::AbstractLuxLayer, x::TrackedArray, ps, st) = m(x, ps, st)
 
 end

--- a/ext/LuxCoreChainRulesCoreExt.jl
+++ b/ext/LuxCoreChainRulesCoreExt.jl
@@ -1,12 +1,12 @@
 module LuxCoreChainRulesCoreExt
 
 using ChainRulesCore: ChainRulesCore, @non_differentiable
-using LuxCore: LuxCore, AbstractExplicitLayer
+using LuxCore: LuxCore, AbstractLuxLayer
 using Random: AbstractRNG
 
 @non_differentiable LuxCore.replicate(::AbstractRNG)
 
-function ChainRulesCore.rrule(::typeof(getproperty), m::AbstractExplicitLayer, x::Symbol)
+function ChainRulesCore.rrule(::typeof(getproperty), m::AbstractLuxLayer, x::Symbol)
     mₓ = getproperty(m, x)
     ∇getproperty(_) = ntuple(Returns(ChainRulesCore.NoTangent()), 3)
     return mₓ, ∇getproperty

--- a/ext/LuxCoreEnzymeCoreExt.jl
+++ b/ext/LuxCoreEnzymeCoreExt.jl
@@ -15,20 +15,20 @@ compute the gradients w.r.t. the layer's parameters, use the first argument retu
 by `LuxCore.setup(rng, layer)` instead.
 """
 
-function EnzymeCore.Active(::LuxCore.AbstractExplicitLayer)
+function EnzymeCore.Active(::LuxCore.AbstractLuxLayer)
     throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
 end
 
 for annotation in (:Duplicated, :DuplicatedNoNeed)
     @eval function EnzymeCore.$(annotation)(
-            ::LuxCore.AbstractExplicitLayer, ::LuxCore.AbstractExplicitLayer)
+            ::LuxCore.AbstractLuxLayer, ::LuxCore.AbstractLuxLayer)
         throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
     end
 end
 
 for annotation in (:BatchDuplicated, :BatchDuplicatedNoNeed)
     @eval function EnzymeCore.$(annotation)(
-            ::LuxCore.AbstractExplicitLayer, ::NTuple{N, <:LuxCore.AbstractExplicitLayer},
+            ::LuxCore.AbstractLuxLayer, ::NTuple{N, <:LuxCore.AbstractLuxLayer},
             check::Bool=true) where {N}
         throw(ArgumentError(LAYER_DERIVATIVE_ERROR_MSG))
     end

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -1,0 +1,25 @@
+module LuxCoreFunctorsExt
+
+using LuxCore: LuxCore
+using Functors: Functors
+
+LuxCore._is_extension_loaded(::Val{:Functors}) = true
+
+LuxCore._isleaf(x) = Functors.isleaf(x)
+LuxCore._fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
+LuxCore._fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
+
+function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
+        x) where {layers}
+    if !LuxCore._is_extension_loaded(Val(:Setfield))
+        throw(ArgumentError("`Functors.functor` for `AbstractLuxContainerLayer` requires \
+                             `Setfield.jl` to be loaded."))
+    end
+    _children = NamedTuple{layers}(getproperty.((x,), layers))
+    layer_reconstructor = let x = x, layers = layers
+        z -> reduce(LuxCore._setfield, zip(layers, z); init=x)
+    end
+    return _children, layer_reconstructor
+end
+
+end

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -18,4 +18,13 @@ function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
     return _children, layer_reconstructor
 end
 
+function Functors.functor(::Type{<:LuxCore.AbstractLuxWrapperLayer{layer}},
+        x) where {layer}
+    _children = NamedTuple{(layer,)}((getproperty(x, layer),))
+    layer_reconstructor = let x = x, layer = layer
+        z -> LuxCore._setfield(x, layer, getproperty(z, layer))
+    end
+    return _children, layer_reconstructor
+end
+
 end

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -3,11 +3,11 @@ module LuxCoreFunctorsExt
 using LuxCore: LuxCore
 using Functors: Functors
 
-LuxCore._is_extension_loaded(::Val{:Functors}) = true
+LuxCore.Internal.is_extension_loaded(::Val{:Functors}) = true
 
-LuxCore.__isleaf(x) = Functors.isleaf(x)
-LuxCore.__fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
-LuxCore.__fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
+LuxCore.Internal.isleaf(x) = Functors.isleaf(x)
+LuxCore.Internal.fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
+LuxCore.Internal.fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
 
 function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
         x) where {layers}

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -13,7 +13,7 @@ function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
         x) where {layers}
     children = NamedTuple{layers}(getproperty.((x,), layers))
     layer_reconstructor = let x = x, layers = layers
-        z -> reduce(LuxCore._setfield, zip(layers, z); init=x)
+        z -> reduce(LuxCore.Internal.setfield, zip(layers, z); init=x)
     end
     return children, layer_reconstructor
 end
@@ -22,7 +22,7 @@ function Functors.functor(::Type{<:LuxCore.AbstractLuxWrapperLayer{layer}},
         x) where {layer}
     children = NamedTuple{(layer,)}((getproperty(x, layer),))
     layer_reconstructor = let x = x, layer = layer
-        z -> LuxCore._setfield(x, layer, getproperty(z, layer))
+        z -> LuxCore.Internal.setfield(x, layer, getproperty(z, layer))
     end
     return children, layer_reconstructor
 end

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -5,26 +5,26 @@ using Functors: Functors
 
 LuxCore.Internal.is_extension_loaded(::Val{:Functors}) = true
 
-LuxCore.Internal.isleaf(x) = Functors.isleaf(x)
-LuxCore.Internal.fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
-LuxCore.Internal.fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
+LuxCore.Internal.isleaf_impl(x) = Functors.isleaf(x)
+LuxCore.Internal.fmap_impl(args...; kwargs...) = Functors.fmap(args...; kwargs...)
+LuxCore.Internal.fleaves_impl(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
 
 function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
         x) where {layers}
-    _children = NamedTuple{layers}(getproperty.((x,), layers))
+    children = NamedTuple{layers}(getproperty.((x,), layers))
     layer_reconstructor = let x = x, layers = layers
         z -> reduce(LuxCore._setfield, zip(layers, z); init=x)
     end
-    return _children, layer_reconstructor
+    return children, layer_reconstructor
 end
 
 function Functors.functor(::Type{<:LuxCore.AbstractLuxWrapperLayer{layer}},
         x) where {layer}
-    _children = NamedTuple{(layer,)}((getproperty(x, layer),))
+    children = NamedTuple{(layer,)}((getproperty(x, layer),))
     layer_reconstructor = let x = x, layer = layer
         z -> LuxCore._setfield(x, layer, getproperty(z, layer))
     end
-    return _children, layer_reconstructor
+    return children, layer_reconstructor
 end
 
 end

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -5,16 +5,12 @@ using Functors: Functors
 
 LuxCore._is_extension_loaded(::Val{:Functors}) = true
 
-LuxCore._isleaf(x) = Functors.isleaf(x)
-LuxCore._fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
-LuxCore._fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
+LuxCore.__isleaf(x) = Functors.isleaf(x)
+LuxCore.__fmap(args...; kwargs...) = Functors.fmap(args...; kwargs...)
+LuxCore.__fleaves(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
 
 function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},
         x) where {layers}
-    if !LuxCore._is_extension_loaded(Val(:Setfield))
-        throw(ArgumentError("`Functors.functor` for `AbstractLuxContainerLayer` requires \
-                             `Setfield.jl` to be loaded."))
-    end
     _children = NamedTuple{layers}(getproperty.((x,), layers))
     layer_reconstructor = let x = x, layers = layers
         z -> reduce(LuxCore._setfield, zip(layers, z); init=x)

--- a/ext/LuxCoreFunctorsExt.jl
+++ b/ext/LuxCoreFunctorsExt.jl
@@ -5,8 +5,11 @@ using Functors: Functors
 
 LuxCore.Internal.is_extension_loaded(::Val{:Functors}) = true
 
-LuxCore.Internal.isleaf_impl(x) = Functors.isleaf(x)
+LuxCore.Internal.isleaf_impl(args...; kwargs...) = Functors.isleaf(args...; kwargs...)
 LuxCore.Internal.fmap_impl(args...; kwargs...) = Functors.fmap(args...; kwargs...)
+function LuxCore.Internal.fmap_with_path_impl(args...; kwargs...)
+    return Functors.fmap_with_path(args...; kwargs...)
+end
 LuxCore.Internal.fleaves_impl(args...; kwargs...) = Functors.fleaves(args...; kwargs...)
 
 function Functors.functor(::Type{<:LuxCore.AbstractLuxContainerLayer{layers}},

--- a/ext/LuxCoreMLDataDevicesExt.jl
+++ b/ext/LuxCoreMLDataDevicesExt.jl
@@ -5,7 +5,7 @@ using MLDataDevices: MLDataDevices
 
 for (dev) in (:CPU, :CUDA, :AMDGPU, :Metal, :oneAPI)
     ldev = Symbol(dev, :Device)
-    @eval function (::MLDataDevices.$(ldev))(NN::LuxCore.AbstractExplicitLayer)
+    @eval function (::MLDataDevices.$(ldev))(NN::LuxCore.AbstractLuxLayer)
         @warn "Lux layers are stateless and hence don't participate in device transfers. \
                Apply this function on the parameters and states generated using \
                `LuxCore.setup`."

--- a/ext/LuxCoreSetfieldExt.jl
+++ b/ext/LuxCoreSetfieldExt.jl
@@ -8,6 +8,8 @@ LuxCore.Internal.is_extension_loaded(::Val{:Setfield}) = true
 function LuxCore.Internal.setfield_impl(x, prop, val)
     return Setfield.set(x, Setfield.PropertyLens{prop}(), val)
 end
-LuxCore.Internal.setfield_impl(x, (prop, val)) = LuxCore.Internal.setfield_impl(x, prop, val)
+function LuxCore.Internal.setfield_impl(x, (prop, val))
+    return LuxCore.Internal.setfield_impl(x, prop, val)
+end
 
 end

--- a/ext/LuxCoreSetfieldExt.jl
+++ b/ext/LuxCoreSetfieldExt.jl
@@ -1,0 +1,11 @@
+module LuxCoreSetfieldExt
+
+using LuxCore: LuxCore
+using Setfield: Setfield
+
+LuxCore._is_extension_loaded(::Val{:Setfield}) = true
+
+LuxCore._setfield(x, prop, val) = Setfield.set(x, Setfield.PropertyLens{prop}(), val)
+LuxCore._setfield(x, (prop, val)) = LuxCore._setfield(x, prop, val)
+
+end

--- a/ext/LuxCoreSetfieldExt.jl
+++ b/ext/LuxCoreSetfieldExt.jl
@@ -5,7 +5,7 @@ using Setfield: Setfield
 
 LuxCore._is_extension_loaded(::Val{:Setfield}) = true
 
-LuxCore._setfield(x, prop, val) = Setfield.set(x, Setfield.PropertyLens{prop}(), val)
-LuxCore._setfield(x, (prop, val)) = LuxCore._setfield(x, prop, val)
+LuxCore.__setfield(x, prop, val) = Setfield.set(x, Setfield.PropertyLens{prop}(), val)
+LuxCore.__setfield(x, (prop, val)) = LuxCore.__setfield(x, prop, val)
 
 end

--- a/ext/LuxCoreSetfieldExt.jl
+++ b/ext/LuxCoreSetfieldExt.jl
@@ -3,9 +3,11 @@ module LuxCoreSetfieldExt
 using LuxCore: LuxCore
 using Setfield: Setfield
 
-LuxCore._is_extension_loaded(::Val{:Setfield}) = true
+LuxCore.Internal.is_extension_loaded(::Val{:Setfield}) = true
 
-LuxCore.__setfield(x, prop, val) = Setfield.set(x, Setfield.PropertyLens{prop}(), val)
-LuxCore.__setfield(x, (prop, val)) = LuxCore.__setfield(x, prop, val)
+function LuxCore.Internal.setfield_impl(x, prop, val)
+    return Setfield.set(x, Setfield.PropertyLens{prop}(), val)
+end
+LuxCore.Internal.setfield_impl(x, (prop, val)) = LuxCore.Internal.setfield_impl(x, prop, val)
 
 end

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -2,7 +2,7 @@ module LuxCore
 
 using Compat: @compat
 using DispatchDoctor: @stable
-using Random: Random, AbstractRNG, Xoshiro
+using Random: Random, AbstractRNG
 
 # PRNG Handling
 """
@@ -332,6 +332,7 @@ end
 
 module Internal
 
+using Random: Xoshiro
 using ..LuxCore: AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer
 
 is_extension_loaded(::Val) = false
@@ -369,6 +370,12 @@ function get_empty_state(l::AbstractLuxContainerLayer{layers}) where {layers}
 end
 function get_empty_state(l::AbstractLuxWrapperLayer{layer}) where {layer}
     return get_empty_state(getfield(l, layer))
+end
+
+function default_layer_check(key)
+    return let key = key
+        x -> hasmethod(keys, (typeof(x),)) ? (key ∈ keys(x)) : false
+    end
 end
 
 end

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -94,13 +94,6 @@ statelength(a::AbstractArray) = length(a)
 statelength(::Any) = 1
 
 """
-    inputsize(layer)
-
-Return the input size of the layer.
-"""
-function inputsize end
-
-"""
     outputsize(layer, x, rng)
 
 Return the output size of the layer.
@@ -383,7 +376,7 @@ end
 @compat(public,
     (replicate, trainmode, testmode, update_state, contains_lux_layer,
         check_fmap_condition, initialparameters, initialstates, parameterlength,
-        statelength, inputsize, outputsize, setup, apply, stateless_apply, display_name))
+        statelength, outputsize, setup, apply, stateless_apply, display_name))
 
 export AbstractLuxLayer, AbstractLuxContainerLayer, AbstractLuxWrapperLayer
 

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -127,21 +127,20 @@ end
 """
     outputsize(layer, x, rng)
 
-Return the output size of the layer. If `outputsize(layer)` is defined, that method
-takes precedence, else we compute the layer output to determine the final size.
+Return the output size of the layer.
 
 The fallback implementation of this function assumes the inputs were batched, i.e.,
 if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
 `size(A)[1:(end - 1)]`. If this behavior is undesirable, provide a custom
 `outputsize(layer, x, rng)` implementation).
+
+!!! warning "Inconsistent Pre-1.0 Behavior"
+
+    Previously it was possible to override this function by defining `outputsize(layer)`.
+    However, this can potentially introduce a bug that is hard to bypass. See
+    [this PR](https://github.com/LuxDL/LuxCore.jl/pull/43) for more information.
 """
 function outputsize(layer, x, rng)
-    if hasmethod(outputsize, Tuple{typeof(layer)})
-        Base.depwarn(
-            "`outputsize(layer)` is deprecated, use `outputsize(layer, x, rng)` instead",
-            :outputsize)
-        return outputsize(layer)
-    end
     ps, st = setup(rng, layer)
     y = first(apply(layer, x, ps, st))
     return __size(y)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -125,7 +125,12 @@ if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
 `outputsize(layer, x, rng)` implementation).
 """
 function outputsize(layer, x, rng)
-    hasmethod(outputsize, Tuple{typeof(layer)}) && return outputsize(layer)
+    if hasmethod(outputsize, Tuple{typeof(layer)})
+        Base.depwarn(
+            "`outputsize(layer)` is deprecated, use `outputsize(layer, x, rng)` instead",
+            :outputsize)
+        return outputsize(layer)
+    end
     ps, st = setup(rng, layer)
     y = first(apply(layer, x, ps, st))
     return __size(y)

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -321,9 +321,6 @@ function check_fmap_condition(cond::C, ::Type{T}, x) where {C, T}
     return check_fmap_condition(cond, nothing, x)
 end
 
-Base.@deprecate_binding AbstractExplicitLayer AbstractLuxLayer false
-Base.@deprecate_binding AbstractExplicitContainerLayer AbstractLuxContainerLayer false
-
 @compat(public,
     (replicate, trainmode, testmode, update_state, contains_lux_layer,
         check_fmap_condition, AbstractLuxLayer, AbstractLuxContainerLayer,

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -15,7 +15,8 @@ Creates a copy of the `rng` state depending on its type.
     return :(deepcopy(rng))
 end
 function replicate(rng::Random.TaskLocalRNG)
-    @warn "`replicate` doesn't work for `TaskLocalRNG`. Returning the same `TaskLocalRNG`." maxlog=1
+    @warn "`replicate` doesn't work for `TaskLocalRNG`. Returning the same \
+           `TaskLocalRNG`." maxlog=1
     return rng
 end
 
@@ -109,17 +110,17 @@ if any of the outputs are Arrays, with `ndims(A) > 1`, it will return
 `size(A)[1:(end - 1)]`. If this behavior is undesirable, provide a custom
 `outputsize(layer, x, rng)` implementation).
 
+!!! warning "Fallback Implementation"
+
+    The fallback implementation of this function is defined once `Lux.jl` is loaded.
+
 !!! warning "Changes from Pre-1.0 Behavior"
 
     Previously it was possible to override this function by defining `outputsize(layer)`.
     However, this can potentially introduce a bug that is hard to bypass. See
     [this PR](https://github.com/LuxDL/LuxCore.jl/pull/43) for more information.
 """
-function outputsize(layer, x, rng)
-    ps, st = setup(rng, layer)
-    y = first(apply(layer, x, ps, st))
-    return Internal.size(y)
-end
+function outputsize end
 
 """
     setup(rng::AbstractRNG, layer)
@@ -358,10 +359,6 @@ function setfield(args...; kwargs...)
     is_extension_loaded(Val(:Setfield)) && return setfield_impl(args...; kwargs...)
     throw(ArgumentError("`setfield` requires `Setfield.jl` to be loaded."))
 end
-
-size_array(x::AbstractArray) = Base.size(x)[1:(ndims(x) - 1)]
-size_array(x::AbstractVector) = Base.size(x)
-size(x) = fmap(size_array, x)
 
 default_rng() = Xoshiro(1234)
 

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -323,8 +323,9 @@ end
 
 @compat(public,
     (replicate, trainmode, testmode, update_state, contains_lux_layer,
-        check_fmap_condition, AbstractLuxLayer, AbstractLuxContainerLayer,
-        initialparameters, initialstates, parameterlength, statelength,
-        inputsize, outputsize, setup, apply, stateless_apply, display_name))
+        check_fmap_condition, initialparameters, initialstates, parameterlength,
+        statelength, inputsize, outputsize, setup, apply, stateless_apply, display_name))
+
+export AbstractLuxLayer, AbstractLuxContainerLayer
 
 end

--- a/src/LuxCore.jl
+++ b/src/LuxCore.jl
@@ -239,6 +239,9 @@ layer to be wrapped in a container.
 Additionally, on calling [`initialparameters`](@ref) and [`initialstates`](@ref), the
 parameters and states are **not** wrapped in a `NamedTuple` with the same name as the
 field.
+
+As a convenience, we define the fallback call `(::AbstractLuxWrapperLayer)(x, ps, st)`,
+which calls `getfield(x, layer)(x, ps, st)`.
 """
 abstract type AbstractLuxWrapperLayer{layer} <: AbstractLuxLayer end
 
@@ -257,6 +260,10 @@ end
 
 function statelength(l::AbstractLuxWrapperLayer{layer}) where {layer}
     return statelength(getfield(l, layer))
+end
+
+function (l::AbstractLuxWrapperLayer{layer})(x, ps, st) where {layer}
+    return apply(getfield(l, layer), x, ps, st)
 end
 
 # Test Mode

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,6 +6,7 @@ Functors = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
 MLDataDevices = "7e8f7934-dd98-4c1a-8fe8-92b47a384d40"
 Optimisers = "3bd65402-5787-11e9-1adc-39752487f4e2"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,23 +1,23 @@
 using LuxCore, Test
 
 @testset "Extension Loading Checks (Fail)" begin
-    @test !LuxCore._is_extension_loaded(Val(:Setfield))
-    @test !LuxCore._is_extension_loaded(Val(:Functors))
-    @test_throws ArgumentError LuxCore._setfield(1, 2, 3)
-    @test_throws ArgumentError LuxCore._fmap(identity, 1)
-    @test_throws ArgumentError LuxCore._fleaves(1)
+    @test !LuxCore.Internal.is_extension_loaded(Val(:Setfield))
+    @test !LuxCore.Internal.is_extension_loaded(Val(:Functors))
+    @test_throws ArgumentError LuxCore.Internal.setfield(1, 2, 3)
+    @test_throws ArgumentError LuxCore.Internal.fmap(identity, 1)
+    @test_throws ArgumentError LuxCore.Internal.fleaves(1)
 end
 
 using Functors, Setfield
 
 @testset "Extension Loading Checks (Pass)" begin
-    @test LuxCore._is_extension_loaded(Val(:Setfield))
-    @test LuxCore._is_extension_loaded(Val(:Functors))
+    @test LuxCore.Internal.is_extension_loaded(Val(:Setfield))
+    @test LuxCore.Internal.is_extension_loaded(Val(:Functors))
 end
 
 using Aqua, ExplicitImports, Optimisers, Random, EnzymeCore, MLDataDevices
 
-rng = LuxCore._default_rng()
+rng = LuxCore.Internal.default_rng()
 
 # Define some custom layers
 struct Dense <: AbstractLuxLayer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, Enzyme
 rng = LuxCore._default_rng()
 
 # Define some custom layers
-struct Dense <: LuxCore.AbstractExplicitLayer
+struct Dense <: LuxCore.AbstractLuxLayer
     in::Int
     out::Int
 end
@@ -15,7 +15,7 @@ end
 
 (::Dense)(x, ps, st) = x, st  # Dummy Forward Pass
 
-struct Chain{L} <: LuxCore.AbstractExplicitContainerLayer{(:layers,)}
+struct Chain{L} <: LuxCore.AbstractLuxContainerLayer{(:layers,)}
     layers::L
 end
 
@@ -25,7 +25,7 @@ function (c::Chain)(x, ps, st)
     return y, (layers = (st1, st2))
 end
 
-struct Chain2{L1, L2} <: LuxCore.AbstractExplicitContainerLayer{(:layer1, :layer2)}
+struct Chain2{L1, L2} <: LuxCore.AbstractLuxContainerLayer{(:layer1, :layer2)}
     layer1::L1
     layer2::L2
 end
@@ -37,7 +37,7 @@ function (c::Chain2)(x, ps, st)
 end
 
 @testset "LuxCore.jl Tests" begin
-    @testset "AbstractExplicitLayer Interface" begin
+    @testset "AbstractLuxLayer Interface" begin
         @testset "Custom Layer" begin
             model = Dense(5, 6)
             x = randn(rng, Float32, 5)
@@ -57,7 +57,7 @@ end
         end
 
         @testset "Default Fallbacks" begin
-            struct NoParamStateLayer <: LuxCore.AbstractExplicitLayer end
+            struct NoParamStateLayer <: LuxCore.AbstractLuxLayer end
 
             layer = NoParamStateLayer()
             @test LuxCore.initialparameters(rng, layer) == NamedTuple()
@@ -83,7 +83,7 @@ end
         end
     end
 
-    @testset "AbstractExplicitContainerLayer Interface" begin
+    @testset "AbstractLuxContainerLayer Interface" begin
         model = Chain((; layer_1=Dense(5, 5), layer_2=Dense(5, 6)))
         x = randn(rng, Float32, 5)
         ps, st = LuxCore.setup(rng, model)
@@ -184,7 +184,7 @@ end
         @testset "Method Ambiguity" begin
             # Needed if defining a layer that works with both Flux and Lux -- See DiffEqFlux.jl
             # See https://github.com/SciML/DiffEqFlux.jl/pull/750#issuecomment-1373874944
-            struct CustomLayer{M, P} <: LuxCore.AbstractExplicitContainerLayer{(:model,)}
+            struct CustomLayer{M, P} <: LuxCore.AbstractLuxContainerLayer{(:model,)}
                 model::M
                 p::P
             end
@@ -198,13 +198,13 @@ end
     end
 
     @testset "Display Name" begin
-        struct StructWithoutName <: LuxCore.AbstractExplicitLayer end
+        struct StructWithoutName <: LuxCore.AbstractLuxLayer end
 
         model = StructWithoutName()
 
         @test LuxCore.display_name(model) == "StructWithoutName"
 
-        struct StructWithName{N} <: LuxCore.AbstractExplicitLayer
+        struct StructWithName{N} <: LuxCore.AbstractLuxLayer
             name::N
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, Enzyme
 rng = LuxCore._default_rng()
 
 # Define some custom layers
-struct Dense <: LuxCore.AbstractLuxLayer
+struct Dense <: AbstractLuxLayer
     in::Int
     out::Int
 end
@@ -15,17 +15,27 @@ end
 
 (::Dense)(x, ps, st) = x, st  # Dummy Forward Pass
 
-struct Chain{L} <: LuxCore.AbstractLuxContainerLayer{(:layers,)}
+struct Chain{L} <: AbstractLuxContainerLayer{(:layers,)}
     layers::L
 end
 
 function (c::Chain)(x, ps, st)
-    y, st1 = c.layers[1](x, ps.layer_1, st.layer_1)
-    y, st2 = c.layers[2](y, ps.layer_2, st.layer_2)
-    return y, (layers = (st1, st2))
+    y, st1 = c.layers[1](x, ps.layers.layer_1, st.layers.layer_1)
+    y, st2 = c.layers[2](y, ps.layers.layer_2, st.layers.layer_2)
+    return y, (; layers = (; layer_1 = st1, layer_2 = st2))
 end
 
-struct Chain2{L1, L2} <: LuxCore.AbstractLuxContainerLayer{(:layer1, :layer2)}
+struct ChainWrapper{L} <: AbstractLuxWrapperLayer{:layers}
+    layers::L
+end
+
+function (c::ChainWrapper)(x, ps, st)
+    y, st1 = c.layers[1](x, ps.layer_1, st.layer_1)
+    y, st2 = c.layers[2](y, ps.layer_2, st.layer_2)
+    return y, (; layer_1 = st1, layer_2 = st2)
+end
+
+struct Chain2{L1, L2} <: AbstractLuxContainerLayer{(:layer1, :layer2)}
     layer1::L1
     layer2::L2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,21 @@
-using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, EnzymeCore,
-      MLDataDevices, Setfield
+using LuxCore, Test
+
+@testset "Extension Loading Checks (Fail)" begin
+    @test !LuxCore._is_extension_loaded(Val(:Setfield))
+    @test !LuxCore._is_extension_loaded(Val(:Functors))
+    @test_throws ArgumentError LuxCore._setfield(1, 2, 3)
+    @test_throws ArgumentError LuxCore._fmap(identity, 1)
+    @test_throws ArgumentError LuxCore._fleaves(1)
+end
+
+using Functors, Setfield
+
+@testset "Extension Loading Checks (Pass)" begin
+    @test LuxCore._is_extension_loaded(Val(:Setfield))
+    @test LuxCore._is_extension_loaded(Val(:Functors))
+end
+
+using Aqua, ExplicitImports, Optimisers, Random, EnzymeCore, MLDataDevices
 
 rng = LuxCore._default_rng()
 
@@ -22,7 +38,7 @@ end
 function (c::Chain)(x, ps, st)
     y, st1 = c.layers[1](x, ps.layers.layer_1, st.layers.layer_1)
     y, st2 = c.layers[2](y, ps.layers.layer_2, st.layers.layer_2)
-    return y, (; layers = (; layer_1 = st1, layer_2 = st2))
+    return y, (; layers=(; layer_1=st1, layer_2=st2))
 end
 
 struct ChainWrapper{L} <: AbstractLuxWrapperLayer{:layers}
@@ -32,7 +48,7 @@ end
 function (c::ChainWrapper)(x, ps, st)
     y, st1 = c.layers[1](x, ps.layer_1, st.layer_1)
     y, st2 = c.layers[2](y, ps.layer_2, st.layer_2)
-    return y, (; layer_1 = st1, layer_2 = st2)
+    return y, (; layer_1=st1, layer_2=st2)
 end
 
 struct Chain2{L1, L2} <: AbstractLuxContainerLayer{(:layer1, :layer2)}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Aqua, ExplicitImports, Functors, LuxCore, Optimisers, Random, Test, EnzymeCore,
-      MLDataDevices
+      MLDataDevices, Setfield
 
 rng = LuxCore._default_rng()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,7 +83,7 @@ end
         end
 
         @testset "Default Fallbacks" begin
-            struct NoParamStateLayer <: LuxCore.AbstractLuxLayer end
+            struct NoParamStateLayer <: AbstractLuxLayer end
 
             layer = NoParamStateLayer()
             @test LuxCore.initialparameters(rng, layer) == NamedTuple()
@@ -265,7 +265,7 @@ end
         @testset "Method Ambiguity" begin
             # Needed if defining a layer that works with both Flux and Lux -- See DiffEqFlux.jl
             # See https://github.com/SciML/DiffEqFlux.jl/pull/750#issuecomment-1373874944
-            struct CustomLayer{M, P} <: LuxCore.AbstractLuxContainerLayer{(:model,)}
+            struct CustomLayer{M, P} <: AbstractLuxContainerLayer{(:model,)}
                 model::M
                 p::P
             end
@@ -279,13 +279,13 @@ end
     end
 
     @testset "Display Name" begin
-        struct StructWithoutName <: LuxCore.AbstractLuxLayer end
+        struct StructWithoutName <: AbstractLuxLayer end
 
         model = StructWithoutName()
 
         @test LuxCore.display_name(model) == "StructWithoutName"
 
-        struct StructWithName{N} <: LuxCore.AbstractLuxLayer
+        struct StructWithName{N} <: AbstractLuxLayer
             name::N
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,8 +77,6 @@ end
             @test LuxCore.stateless_apply(model, x, ps) ==
                   first(LuxCore.apply(model, x, ps, NamedTuple()))
 
-            # the layer just passes x along
-            @test LuxCore.outputsize(model, x, rng) == (5,)
             @test_nowarn println(model)
         end
 
@@ -147,9 +145,6 @@ end
 
         @test LuxCore.stateless_apply(model, x, ps) ==
               first(LuxCore.apply(model, x, ps, st))
-
-        # the layers just pass x along
-        @test LuxCore.outputsize(model, x, rng) == (5,)
 
         @test_nowarn println(model)
     end
@@ -231,9 +226,6 @@ end
             @test new_model.layers.layer_2.in == 5
             @test new_model.layers.layer_2.out == 10
 
-            @test LuxCore.outputsize(model, rand(5), rng) == (5,)
-            @test LuxCore.outputsize(model, rand(5, 2), rng) == (5,)
-
             model = ChainWrapper((; layer_1=Dense(5, 10), layer_2=Dense(10, 5)))
 
             children, reconstructor = Functors.functor(model)
@@ -257,9 +249,6 @@ end
             @test new_model.layers.layer_1.out == 5
             @test new_model.layers.layer_2.in == 5
             @test new_model.layers.layer_2.out == 10
-
-            @test LuxCore.outputsize(model, rand(5), rng) == (5,)
-            @test LuxCore.outputsize(model, rand(5, 2), rng) == (5,)
         end
 
         @testset "Method Ambiguity" begin


### PR DESCRIPTION
This changelog needs to be put in Lux. I will copy it over later.

merge after #42 

## Changelog

- `AbstractExplicit...` names have been changed to `AbstractLux...`.
- `Functors.jl` and `Setfield.jl` are non-essential dependencies and have been moved into extensions.
- Removes `inputsize` since that wasn't being used anywhere.
- Single argument `outputsize` is no longer supported.
  - Fallback `outputsize` is now only defined once Lux.jl is loaded
- fixes https://github.com/LuxDL/Lux.jl/issues/795
  - `AbstractLuxContainerLayer{(:a,)}` wraps the `initialparameters` and `initialstates` with a NamedTuple with a single field `a`.
  - Previous behavior of unwrapped NamedTuple is provided via `AbstractLuxWrapperLayer`.